### PR TITLE
Do not install recommended packages for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN --mount=type=cache,sharing=shared,target=/var/cache \
     --mount=type=tmpfs,target=/usr/share/doc \
     apt-get update \
     && apt-get install -y eatmydata \
-    && eatmydata apt-get install -y qemu-user-static \
+    && eatmydata apt-get install -y --no-recommends \
+        qemu-user-static \
         binfmt-support gdisk kpartx \
         parted \
         autoconf automake autotools-dev bc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,sharing=shared,target=/var/cache \
     --mount=type=tmpfs,target=/usr/share/doc \
     apt-get update \
     && apt-get install -y eatmydata \
-    && eatmydata apt-get install -y --no-recommends \
+    && eatmydata apt-get install -y --no-install-recommends \
         qemu-user-static \
         binfmt-support gdisk kpartx \
         parted \


### PR DESCRIPTION
It's good practice to disable recommended packages to reduce download size and speed things up.